### PR TITLE
Fix loader failing when plugins field not declared

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -10,8 +10,8 @@ const Report = require('vfile-reporter')
  * @param   {object} options  - Options passed to the loader
  * @returns {object}          - HTML and imports
  */
-module.exports = function(markdown, options = {}) {
-    let { plugins = [] } = options,
+module.exports = function(markdown, options) {
+    let { plugins = [] } = (options || {}),
         parsed = FrontMatter(markdown)
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Hey there, with a loader config like this:

```js
{
  test: /\.md$/,
  use: [{
    loader: "remark-loader"
  }]
}
``` 

I get this error:

```
Error: Module build failed (from ./node_modules/remark-loader/src/index.js):
TypeError: Cannot read property 'plugins' of null
    at module.exports (./node_modules/remark-loader/src/parse.js:14:11)
    at Object.module.exports (./node_modules/remark-loader/src/index.js:14:5)
```

This is because you use a default param for `options`:
https://github.com/skipjack/remark-loader/blob/9d225937536d4b8d5a68e91dadcd71eece563d3c/src/parse.js#L13

But presumably `Utils.getOptions` returns `null` rather than `undefined` when no options are declared in the loader config:
https://github.com/skipjack/remark-loader/blob/9d225937536d4b8d5a68e91dadcd71eece563d3c/src/index.js#L12

Default params aren't applied if a function is passed `null`! This PR should resolve this (but this is just a quick fix from GitHub's in-browser editor UI, I didn't test this myself).